### PR TITLE
raise Error when Twitter API returned error

### DIFF
--- a/lib/simple_twitter.rb
+++ b/lib/simple_twitter.rb
@@ -3,6 +3,24 @@ require 'simple_oauth'
 
 module SimpleTwitter
   class Error < StandardError
+    # @!attribute [r] raw_response
+    # @return [HTTP::Response] raw error response
+    attr_reader :raw_response
+
+    # @!attribute [r] body
+    # @return [Hash<Symbol, String>] error response body
+    attr_reader :body
+
+    # @param raw_response [HTTP::Response] raw error response from Twitter API
+    def initialize(raw_response)
+      @raw_response = raw_response
+      @body = JSON.parse(raw_response.to_s, symbolize_names: true)
+
+      title = @body[:title] || "Unknown error"
+      title << " (status #{raw_response.code})"
+
+      super(title)
+    end
   end
 
   class ClientError < Error
@@ -75,9 +93,9 @@ module SimpleTwitter
     def parse_response(res)
       case res.code.to_i / 100
       when 4
-        raise ClientError, res.to_s
+        raise ClientError, res
       when 5
-        raise ServerError, res.to_s
+        raise ServerError, res
       end
 
       JSON.parse(res.to_s, symbolize_names: true)


### PR DESCRIPTION
# Motivation
Currently, even if the Twitter API returns an error, Ruby does not throw an error, so it is considered a normal exit.

This is confusing, so when the API returns an error, Ruby also raises an error.

# Before
```ruby
client = SimpleTwitter::Client.new(bearer_token: "dummy")
client.get("https://api.twitter.com/2/users/me")
#=> 
{:title=>"Unsupported Authentication",
 :detail=>
  "Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].",
 :type=>"https://api.twitter.com/2/problems/unsupported-authentication",
 :status=>403}
```

# After
```ruby
client = SimpleTwitter::Client.new(bearer_token: "dummy")
client.get("https://api.twitter.com/2/users/me")
/Users/sue445/workspace/github.com/yhara/simple_twitter/lib/simple_twitter.rb:80:in `parse_response': { (SimpleTwitter::ClientError)
  "title": "Unsupported Authentication", 
  "detail": "Authenticating with OAuth 2.0 Application-Only is forbidden for this endpoint.  Supported authentication types are [OAuth 1.0a User Context, OAuth 2.0 User Context].",                            
  "type": "https://api.twitter.com/2/problems/unsupported-authentication",
  "status": 403
}
        from (eval):6:in `get'
        from (irb):3:in `<main>'
        from /Users/sue445/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/irb-1.6.2/exe/irb:11:in `<top (required)>'
```
