### PR TITLE
Pass json arg to http methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,20 @@ pp client.post("https://api.twitter.com/1.1/statuses/update.json",
 
 You can get the access_token and access_token_secret for your own at the Twitter Developer Portal. For other users, you need to get them via OAuth (out of scope of this gem.)
 
+### Post with JSON body
+Since Twitter API v2, POST must be sent as JSON body
+
+e.g.https://developer.twitter.com/en/docs/twitter-api/tweets/manage-tweets/api-reference/post-tweets
+
+Send using the `json` argument.
+
+e.g.
+
+```ruby
+client = SimpleTwitter::Client.new(bearer_token: ENV["ACCESS_TOKEN"])
+client.post("https://api.twitter.com/2/tweets", json: { text: "Hello twitter!" })
+```
+
 ### Advanced
 
 If you want the raw json string or use streaming API, use `get_raw`, `post_raw`, etc. which returns `HTTP::Response` of the [http gem](https://github.com/httprb/http).

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ require 'simple_twitter'
 
 client = SimpleTwitter::Client.new(bearer_token: "...")
 pp client.get("https://api.twitter.com/2/tweets",
-              ids: "1302127884039909376,1369885448319889409")
+              params: { ids: "1302127884039909376,1369885448319889409" })
 ```
 
 Result:
@@ -55,7 +55,7 @@ client = SimpleTwitter::Client.new(
   access_token_secret: config[:access_token_secret],
 )
 pp client.post("https://api.twitter.com/1.1/statuses/update.json",
-               status: "Test.")
+               params: { status: "Test." })
 ```
 
 You can get the access_token and access_token_secret for your own at the Twitter Developer Portal. For other users, you need to get them via OAuth (out of scope of this gem.)
@@ -77,7 +77,7 @@ end
 Some API parameters has `.` in its name (eg. `tweet.fields`.) Did you know that in Ruby you can include `.` in a hash key if quoted? :-)
 
 ```rb
-tweets = @client.get("https://api.twitter.com/2/users/#{id}/tweets", {
+tweets = @client.get("https://api.twitter.com/2/users/#{id}/tweets", params: {
   expansions: "author_id",
   max_results: 100,
   "tweet.fields": "author_id,created_at,referenced_tweets,text",

--- a/lib/simple_twitter.rb
+++ b/lib/simple_twitter.rb
@@ -52,14 +52,16 @@ module SimpleTwitter
         # @return [Object] parsed json data
         # @raise [SimpleTwitter::ClientError] Twitter API returned 4xx error
         # @raise [SimpleTwitter::ServerError] Twitter API returned 5xx error
-        def #{m}(url, params={})
-          res = #{m}_raw(url, params)
+        def #{m}(url, params={}, json=nil)
+          res = #{m}_raw(url, params, json)
           parse_response(res)
         end
 
         # @return [HTTP::Response]
-        def #{m}_raw(url, params={})
-          http(:#{m}, url, params).#{m}(url, params: params)
+        def #{m}_raw(url, params={}, json=nil)
+          args = { params: params }
+          args[:json] = json if json
+          http(:#{m}, url, params).#{m}(url, args)
         end
       EOD
     end

--- a/lib/simple_twitter.rb
+++ b/lib/simple_twitter.rb
@@ -49,16 +49,18 @@ module SimpleTwitter
 
     %i[get post put delete].each do |m|
       class_eval <<~EOD
+        # @param params [Hash] Send this arg as a query string. (e.g. `?name1=value1&name2=value2`)
+        # @param json [Hash] Send this arg as JSON request body with "Content-Type: application/json" header
         # @return [Object] parsed json data
         # @raise [SimpleTwitter::ClientError] Twitter API returned 4xx error
         # @raise [SimpleTwitter::ServerError] Twitter API returned 5xx error
-        def #{m}(url, params={}, json=nil)
+        def #{m}(url, params: {}, json: nil)
           res = #{m}_raw(url, params, json)
           parse_response(res)
         end
 
         # @return [HTTP::Response]
-        def #{m}_raw(url, params={}, json=nil)
+        def #{m}_raw(url, params: {}, json: nil)
           args = { params: params }
           args[:json] = json if json
           http(:#{m}, url, params).#{m}(url, args)


### PR DESCRIPTION
# Motivation
Some endpoints of the API require passing json in POST.

Therefore, I have made it possible to pass json

# Before
```ruby
client = SimpleTwitter::Client.new(bearer_token: ENV["BEARER_TOKEN"])

client.post("https://api.twitter.com/2/tweets", text: "Hello world!")
#=> {:errors=>[{:parameters=>{:text=>["Hello world!"]}, :message=>"The query parameter [text] is not one of [expansions,tweet.fields,media.fields,poll.fields,place.fields,user.fields]"}], :title=>"Invalid Request", :detail=>"One or more parameters to your request was invalid.", :type=>"https://api.twitter.com/2/problems/invalid-request"}
```

# After
```ruby
client = SimpleTwitter::Client.new(bearer_token: ENV["BEARER_TOKEN"])

client.post("https://api.twitter.com/2/tweets", {}, { text: "Hello world!"})
```
