### PR TITLE
Enabled rubygems_mfa_required

### DIFF
--- a/simple_twitter.gemspec
+++ b/simple_twitter.gemspec
@@ -15,6 +15,7 @@ Gem::Specification.new do |spec|
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
   #spec.metadata["changelog_uri"] = "TODO: Put your gem's CHANGELOG.md URL here."
+  spec.metadata["rubygems_mfa_required"] = "true"
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.


### PR DESCRIPTION
@yhara I would like to make MFA mandatory for gem releases to increase gem security (e.g. Supply Chain Attack).

ref. https://guides.rubygems.org/mfa-requirement-opt-in/

If you want to release a gem next time, please set up MFA first at https://rubygems.org/settings/edit 🙏 