### PR TITLE
[docs] Fix YARD warning

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -45,3 +45,4 @@ jobs:
           bundle update --jobs $(nproc) --retry 3
 
       - run: bundle exec rspec
+      - run: bundle exec yard --fail-on-warning

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,7 @@ See more.
 - Tweak doc
   - https://github.com/yhara/simple_twitter/pull/17
   - https://github.com/yhara/simple_twitter/pull/18
+  - https://github.com/yhara/simple_twitter/pull/20
 
 ## v1.0.0 (2021-03-28)
 

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ rescue SimpleTwitter::Error => error
 end
 ```
 
-See more. [`SimpleTwitter::Error`](https://yhara.github.io/simple_twitter/SimpleTwitter/Error.html)
+See more. [SimpleTwitter::Error](https://yhara.github.io/simple_twitter/SimpleTwitter/Error.html)
 
 ## API Reference
 See https://yhara.github.io/simple_twitter/


### PR DESCRIPTION
```
$ bundle exec yard
[warn]: In file `README.md':121: Cannot resolve link to <code>SimpleTwitter::Error</code><a from text:
        ...{<code>SimpleTwitter::Error</code><a href="https://yhara.github.io/simple_twitter/SimpleTwitter/Error.html">}...
[warn]: In file `README.md':121: Cannot resolve link to <code>SimpleTwitter::Error</code><a from text:
        ...{<code>SimpleTwitter::Error</code><a href="https://yhara.github.io/simple_twitter/SimpleTwitter/Error.html">}...

```