### PR TITLE
Embed filename and line number of the method generated by eval into backtrace

### DIFF
--- a/lib/simple_twitter/client.rb
+++ b/lib/simple_twitter/client.rb
@@ -111,7 +111,7 @@ module SimpleTwitter
     #   @see https://www.rubydoc.info/github/httprb/http/HTTP/Response HTTP::Response documentation
 
     %i[get post put delete].each do |m|
-      class_eval <<~EOD
+      class_eval <<~EOD, __FILE__, __LINE__ + 1
         def #{m}(url, params: {}, json: {}, form: {})
           res = #{m}_raw(url, params: params, json: json, form: form)
           parse_response(res)


### PR DESCRIPTION
# Before
```ruby
irb(main):001:0> client = SimpleTwitter::Client.new(bearer_token: "dummy")
irb(main):002:0> client.get("https://api.twitter.com/2/users/me")
/Users/sue445/workspace/github.com/yhara/simple_twitter/lib/simple_twitter/client.rb:173:in `parse_response': Unsupported Authentication (status 403) (SimpleTwitter::ClientError)
	from (eval):3:in `get'
	from (irb):2:in `<main>'
	from ./bin/console:24:in `<main>'
```

# After
```ruby
irb(main):001:0> client = SimpleTwitter::Client.new(bearer_token: "dummy")
irb(main):002:0> client.get("https://api.twitter.com/2/users/me")
/Users/sue445/workspace/github.com/yhara/simple_twitter/lib/simple_twitter/client.rb:173:in `parse_response': Unsupported Authentication (status 403) (SimpleTwitter::ClientError)
	from /Users/sue445/workspace/github.com/yhara/simple_twitter/lib/simple_twitter/client.rb:117:in `get'
	from (irb):2:in `<main>'
	from ./bin/console:24:in `<main>'
```