### PR TITLE
Support http gem v6

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,7 +61,6 @@ jobs:
           bundle update --jobs $(nproc) --retry 3
 
       - run: bundle exec rspec
-      - run: bundle exec yard --fail-on-warning
 
   rbs:
     runs-on: ubuntu-latest
@@ -104,5 +103,5 @@ jobs:
       - name: yard generating test
         run: |
           set -xe
-          bundle exec yard
+          bundle exec yard --fail-on-warning
           ls -ld doc/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -37,6 +37,12 @@ jobs:
           - http_6
 
         exclude:
+          # http gem v5+ requires Ruby 2.5+
+          - ruby: "2.3"
+            gemfile: http_5
+          - ruby: "2.4"
+            gemfile: http_5
+
           # http gem v6+ requires Ruby 3.2+
           - ruby: "2.3"
             gemfile: http_6

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,6 +12,8 @@ on:
 
 jobs:
   test:
+    name: "test (Ruby ${{ matrix.ruby }}, gemfile ${{ matrix.gemfile }})"
+
     runs-on: ubuntu-latest
 
     strategy:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,6 +36,23 @@ jobs:
           - http_5
           - http_6
 
+        exclude:
+          # http gem v6+ requires Ruby 3.2+
+          - ruby: "2.3"
+            gemfile: http_6
+          - ruby: "2.4"
+            gemfile: http_6
+          - ruby: "2.5"
+            gemfile: http_6
+          - ruby: "2.6"
+            gemfile: http_6
+          - ruby: "2.7"
+            gemfile: http_6
+          - ruby: "3.0"
+            gemfile: http_6
+          - ruby: "3.1"
+            gemfile: http_6
+
         include:
           # FIXME: Workaround for "ArgumentError: wrong number of arguments (given 4, expected 1)"
           # c.f. https://github.com/ruby/setup-ruby#rubygems

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,11 +31,19 @@ jobs:
           - "3.4"
           - "4.0"
 
+        gemfile:
+          - http_4
+          - http_5
+          - http_6
+
         include:
           # FIXME: Workaround for "ArgumentError: wrong number of arguments (given 4, expected 1)"
           # c.f. https://github.com/ruby/setup-ruby#rubygems
           - ruby: "2.5"
             rubygems: "3.0.0"
+
+    env:
+      BUNDLE_GEMFILE: gemfiles/${{ matrix.gemfile }}.gemfile
 
     steps:
       - uses: actions/checkout@v6.0.1
@@ -53,6 +61,7 @@ jobs:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true
           rubygems: ${{ matrix.rubygems || 'default' }}
+          cache-version: ${{ matrix.gemfile }}
 
       - name: bundle update
         run: |

--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in simple_twitter.gemspec
 gemspec
 
-gem "rake", "~> 13.0"
-
 # FIXME: rbs bundled with ffi v1.17.0+ is broken
 # c.f. https://github.com/ffi/ffi/issues/1107
 gem "ffi", "< 1.17.0"

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,4 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in simple_twitter.gemspec
 gemspec
 
-# FIXME: rbs bundled with ffi v1.17.0+ is broken
-# c.f. https://github.com/ffi/ffi/issues/1107
-gem "ffi", "< 1.17.0"
+eval_gemfile "#{__dir__}/gemfiles/common.gemfile"

--- a/gemfiles/common.gemfile
+++ b/gemfiles/common.gemfile
@@ -1,0 +1,3 @@
+# FIXME: rbs bundled with ffi v1.17.0+ is broken
+# c.f. https://github.com/ffi/ffi/issues/1107
+gem "ffi", "< 1.17.0"

--- a/gemfiles/http_4.gemfile
+++ b/gemfiles/http_4.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "http", "~> 4.0"
+
+eval_gemfile "#{__dir__}/common.gemfile"
+
+gemspec path: "../"

--- a/gemfiles/http_5.gemfile
+++ b/gemfiles/http_5.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "http", "~> 5.0"
+
+eval_gemfile "#{__dir__}/common.gemfile"
+
+gemspec path: "../"

--- a/gemfiles/http_6.gemfile
+++ b/gemfiles/http_6.gemfile
@@ -1,0 +1,7 @@
+source "https://rubygems.org"
+
+gem "http", "~> 6.0"
+
+eval_gemfile "#{__dir__}/common.gemfile"
+
+gemspec path: "../"

--- a/lib/simple_twitter/client.rb
+++ b/lib/simple_twitter/client.rb
@@ -119,7 +119,12 @@ module SimpleTwitter
 
         def #{m}_raw(url, params: {}, json: {}, form: {})
           args = create_http_args(params: params, json: json, form: form)
-          http(:#{m}, url, params).#{m}(url, args)
+
+          if http_v6_or_later?
+            http(:#{m}, url, params).#{m}(url, **args)
+          else
+            http(:#{m}, url, params).#{m}(url, args)
+          end
         end
       EOD
     end
@@ -140,6 +145,11 @@ module SimpleTwitter
       args[:json] = json unless json.empty?
       args[:form] = form unless form.empty?
       args
+    end
+
+    # @return [Boolean]
+    def http_v6_or_later?
+      Gem::Version.new(HTTP::VERSION) >= Gem::Version.new("6.0.0")
     end
 
     # @param method [Symbol]

--- a/rbs_collection.lock.yaml
+++ b/rbs_collection.lock.yaml
@@ -17,6 +17,14 @@ gems:
   version: '0'
   source:
     type: stdlib
+- name: cgi
+  version: '0.5'
+  source:
+    type: git
+    name: ruby/gem_rbs_collection
+    revision: ecdc16fbc015cc667476120bdc2bd20735882f3a
+    remote: https://github.com/ruby/gem_rbs_collection.git
+    repo_dir: gems
 - name: delegate
   version: '0'
   source:
@@ -53,6 +61,22 @@ gems:
     revision: 2c49b34efb3ab42ec5160e1870c23d8349adb157
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: io-console
+  version: '0'
+  source:
+    type: stdlib
+- name: pp
+  version: '0'
+  source:
+    type: stdlib
+- name: prettyprint
+  version: '0'
+  source:
+    type: stdlib
+- name: prism
+  version: 1.9.0
+  source:
+    type: rubygems
 - name: rake
   version: '13.0'
   source:
@@ -61,6 +85,10 @@ gems:
     revision: 2c49b34efb3ab42ec5160e1870c23d8349adb157
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: rdoc
+  version: '0'
+  source:
+    type: stdlib
 - name: simple_oauth
   version: '0.3'
   source:
@@ -69,6 +97,14 @@ gems:
     revision: 2c49b34efb3ab42ec5160e1870c23d8349adb157
     remote: https://github.com/ruby/gem_rbs_collection.git
     repo_dir: gems
+- name: stringio
+  version: '0'
+  source:
+    type: stdlib
+- name: tempfile
+  version: '0'
+  source:
+    type: stdlib
 - name: webmock
   version: '3.19'
   source:

--- a/sig/non-gemify/http.rbs
+++ b/sig/non-gemify/http.rbs
@@ -1,0 +1,3 @@
+module HTTP
+  VERSION: String
+end

--- a/sig/simple_twitter/client.rbs
+++ b/sig/simple_twitter/client.rbs
@@ -22,6 +22,7 @@ module SimpleTwitter
 
     def create_http_args: (params: Hash[Symbol, untyped], json: Hash[Symbol, untyped], form: Hash[Symbol, untyped]) -> Hash[Symbol, untyped]
     def http: (Symbol method, String url, Hash[Symbol, String] params) -> HTTP::Client
+    def http_v6_or_later?: () -> bool
     def auth_header: (Symbol method, String url, Hash[Symbol, String] params) -> String
     def parse_response: (HTTP::Response res) -> Hash[Symbol, untyped]
   end

--- a/simple_twitter.gemspec
+++ b/simple_twitter.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
 
   spec.add_development_dependency "dotenv"
   spec.add_development_dependency "irb"
+  spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rdoc"
   spec.add_development_dependency "rspec"
   spec.add_development_dependency "rspec-its"

--- a/simple_twitter.gemspec
+++ b/simple_twitter.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
-    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features)/}) }
+    `git ls-files -z`.split("\x0").reject { |f| f.match(%r{\A(?:test|spec|features|sig/non-gemify)/}) }
   end
   spec.bindir        = "exe"
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }


### PR DESCRIPTION
Fix following error

```
  1) SimpleTwitter::Client get with params (API v2) get response
     Failure/Error:
               def #{m}(url, params: {}, json: {}, form: {})
                 res = #{m}_raw(url, params: params, json: json, form: form)
                 parse_response(res)
               end
       
               def #{m}_raw(url, params: {}, json: {}, form: {})
                 args = create_http_args(params: params, json: json, form: form)
                 http(:#{m}, url, params).#{m}(url, args)
               end

     ArgumentError:
       wrong number of arguments (given 2, expected 1)
     # ./vendor/bundle/ruby/4.0.0/gems/http-6.0.2/lib/http/chainable/verbs.rb:33:in 'HTTP::Chainable::Verbs#get'
     # ./lib/simple_twitter/client.rb:122:in 'SimpleTwitter::Client#get_raw'
     # ./lib/simple_twitter/client.rb:116:in 'SimpleTwitter::Client#get'
     # ./spec/simple_twitter/client_spec.rb:5:in 'block (3 levels) in <top (required)>'
     # ./spec/simple_twitter/client_spec.rb:20:in 'block (3 levels) in <top (required)>'
     # ./vendor/bundle/ruby/4.0.0/gems/webmock-3.26.2/lib/webmock/rspec.rb:39:in 'block (2 levels) in <top (required)>'
```

https://github.com/yhara/simple_twitter/actions/runs/23816980120/job/69418977546